### PR TITLE
demo: endo-based trading agent (WIP)

### DIFF
--- a/contract/test/endo/Makefile
+++ b/contract/test/endo/Makefile
@@ -1,0 +1,41 @@
+STATE=$(shell endo where state)
+PET=$(STATE)/pet-store
+
+# ag-trade package is currently in finquick
+# https://github.com/dckc/finquick
+AG_TRADE=~/projects/finquick/packages/ag-trade
+
+reserve-add: reserve-add.js $(PET)/alice
+	endo run reserve-add.js 1 IST -p alice
+
+$(PET)/alice: $(PET)/alice-wk $(PET)/fresh-trade-id
+	endo mkguest alice
+
+	endo send alice @wallet:alice-wk
+	endo send alice @fresh:fresh-trade-id
+	endo inbox --as alice
+	# these 0/1 message numbers are fragile
+	endo adopt 0 wallet --as alice
+	endo adopt 1 fresh --as alice
+
+$(PET)/fresh-trade-id: $(PET)/fresh
+	endo eval "E(fresh).start('trade-')" fresh -n fresh-trade-id
+
+# making fresh IDs requires non-deterministic inputs
+$(PET)/fresh: fresh-id.js
+	endo make --UNSAFE fresh-id.js -n fresh
+
+# in makeWalletKit, it's too easy to get the rpc, lcd order wrong. should be named
+$(PET)/alice-wk: $(PET)/local $(PET)/client-maker
+	endo eval "E(wf).makeWalletKit('${ALICE_SECRET}', local.rpc, local.lcd)" \
+		local wf:client-maker -n alice-wk
+
+$(PET)/local: net-local.js $(PET)/cosmos-fetch
+	endo make net-local.js -n local -p cosmos-fetch
+
+# plugins from ag-trade
+$(PET)/client-maker:
+	make -C $(AG_TRADE) $@
+
+$(PET)/cosmos-fetch:
+	make -C $(AG_TRADE) $@

--- a/contract/test/endo/ag-trade.js
+++ b/contract/test/endo/ag-trade.js
@@ -1,0 +1,43 @@
+export {};
+
+/** @typedef {import('@agoric/smart-wallet/src/offers').OfferSpec} OfferSpec */
+/** @typedef {import('@agoric/smart-wallet/src/offers').OfferStatus} OfferStatus */
+/** @typedef {import('@agoric/smart-wallet/src/smartWallet').CurrentWalletRecord} CurrentWalletRecord */
+/** @typedef {import('@agoric/smart-wallet/src/smartWallet').UpdateRecord} UpdateRecord */
+
+/**
+ * @template T
+ * @typedef {{
+ *   visit: (x: T) => Promise<void>
+ * }} Visitor
+ */
+
+/**
+ * @typedef {{
+ *   executeOffer: (offer: OfferSpec, fee?: string) => Promise<{
+ *       tx: { transactionHash: string, height: number },
+ *       status: OfferStatus
+ *     }>;
+ *   readOnly: () => Promise<SmartWalletView>
+ * }} SmartWallet
+ *
+ * @typedef {{
+ *   current: () => Promise<CurrentWalletRecord>,
+ *   history: (vistor: Visitor<UpdateRecord>, minHeight?: number) => Promise<void>
+ * }} SmartWalletView
+ *
+ * @typedef {{
+ *   query: QueryTool,
+ *   smartWallet: SmartWallet,
+ *   tx: unknown,
+ * }} SmartWalletKit
+ */
+
+/**
+ * @typedef {{
+ *   queryData: (path: string) => Promise<any>,
+ *   queryChildren: (path: string) => Promise<string[]>,
+ *   lookup(...path: string[]) => Promise<any>,
+ *   invalidate() => Promise<any>,
+ * }} QueryTool
+ */

--- a/contract/test/endo/alice-trade.js
+++ b/contract/test/endo/alice-trade.js
@@ -1,0 +1,84 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+import { mustMatch, M } from '@endo/patterns';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
+
+import {
+  contractName,
+  feeValue,
+  wellKnownIdentities,
+} from './well-known.js/index.js';
+
+console.log('***alice-trade worker');
+
+/**
+ * @param {import('./ag-trade.js').QueryTool} vstorage
+ * @param {import('./ag-trade.js').SmartWallet} wallet
+ */
+export const alice = async (vstorage, wallet) => {
+  /**
+   * @param {string|number} id
+   * @param {Amount} beansAmount
+   * @param {Amount} cowsAmount
+   * @param {string} depositAddress
+   * @param {boolean} [alicePays]
+   */
+  const trade = async (
+    id,
+    beansAmount,
+    cowsAmount,
+    depositAddress,
+    alicePays = true,
+  ) => {
+    mustMatch(
+      harden({ id, beansAmount, cowsAmount, depositAddress, alicePays }),
+      harden({
+        id: M.string(),
+        beansAmount: AmountShape,
+        cowsAmount: AmountShape,
+        depositAddress: M.string(),
+        alicePays: M.boolean(),
+      }),
+    );
+
+    const wellKnown = await wellKnownIdentities(vstorage);
+
+    const feeAmount = AmountMath.make(wellKnown.brand.IST, feeValue);
+
+    const proposal = {
+      give: { MagicBeans: beansAmount, Fee: feeAmount },
+      want: {
+        Cow: cowsAmount,
+        ...(alicePays ? {} : { Refund: feeAmount }),
+      },
+    };
+
+    /** @type {import('./ag-trade.js').OfferSpec} */
+    const offerSpec = {
+      id,
+      invitationSpec: {
+        source: 'contract',
+        instance: wellKnown.instance[contractName],
+        publicInvitationMaker: 'makeFirstInvitation',
+        invitationArgs: [[wellKnown.issuer.BLD, wellKnown.issuer.IST]],
+      },
+      proposal,
+      offerArgs: { addr: depositAddress },
+    };
+
+    return E(wallet).executeOffer(offerSpec);
+  };
+
+  return Far('Alice', {
+    wellKnown: () => wellKnownIdentities(vstorage),
+    trade,
+  });
+};
+
+export const make = async powers => {
+  /** @type {import('./ag-trade.js').SmartWalletKit} */
+  const kit = await E(powers).request('HOST', 'wallet kit', 'wallet-kit');
+
+  return alice(kit.query, kit.smartWallet);
+};

--- a/contract/test/endo/bag-tool.js
+++ b/contract/test/endo/bag-tool.js
@@ -1,0 +1,19 @@
+// @ts-check
+import { Far } from '@endo/far';
+import { getCopyBagEntries, makeCopyBag } from '@endo/patterns';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+
+export const make = () =>
+  Far('BagTool', {
+    /**
+     * @param {Amount<'copyBag'>} amt
+     * @param  {number[]} targets
+     */
+    pick: (amt, ...targets) =>
+      AmountMath.make(
+        amt.brand,
+        makeCopyBag(
+          getCopyBagEntries(amt.value).filter((_, ix) => targets.includes(ix)),
+        ),
+      ),
+  });

--- a/contract/test/endo/fresh-id.js
+++ b/contract/test/endo/fresh-id.js
@@ -1,0 +1,74 @@
+// @ts-check
+import { Far } from '@endo/far';
+
+const trunc = {
+  day: t => t.slice(0, '2001-01-01'.length),
+  min: t => t.slice(0, '2001-01-01 hh:mm'.length),
+  sec: t => t.slice(0, '2001-01-01 hh:mm:ss'.length),
+};
+const pick = {
+  time: t => t.slice('2001-01-01 '.length),
+};
+
+const next = (t, slug = '_', t0, prev, seq) => {
+  const firstDay = trunc.day(t) === trunc.day(t0);
+  let lhs = t;
+  for (const truncf of [trunc.min, trunc.sec]) {
+    const cand = truncf(lhs);
+    if (cand > truncf(prev)) {
+      lhs = cand;
+      break;
+    }
+  }
+  const friendly = (firstDay ? pick.time(lhs) : lhs).replace(/:/g, '');
+  return `${slug}${friendly}.${seq}`;
+};
+
+/**
+ * @param {unknown} _powers
+ * @param {{ now?: () => number }} io
+ */
+export const make = (_powers, io = {}) => {
+  const { now = () => Date.now() } = io;
+
+  const start = (slug = '') => {
+    const t0 = new Date(now()).toISOString();
+    let seq = 0n;
+    let prev = trunc.day(t0);
+    return Far('Fresh', {
+      next: () => {
+        const t = new Date(now()).toISOString();
+        const out = next(t, slug, t0, prev, seq);
+        prev = t;
+        seq += 1n;
+        return out;
+      },
+    });
+  };
+
+  const test = () => {
+    const seq = 1n;
+    const slug = 'x-';
+    const t0 = '2023-12-29T19:10:10.466Z';
+    const cases = [
+      { t: '2023-12-29T19:10:10.466Z', prev: '2023-12-29T19:10:10.466Z' },
+      { t: '2023-12-29T19:15:10.466Z', prev: '2023-12-29T19:10:10.466Z' },
+      { t: '2023-12-29T19:15:33.466Z', prev: '2023-12-29T19:15:10.466Z' },
+      { t: '2023-12-30T19:15:33.466Z', prev: '2023-12-29T19:15:10.466Z' },
+    ];
+    const results = [];
+    for (const { t, prev } of cases) {
+      const out = next(t, slug, t0, prev, seq);
+      results.push({ out, t, prev });
+    }
+    return results;
+  };
+
+  //   const it = Far('FreshMaker', { start, test });
+  //   return it.test();
+
+  return Far('FreshMaker', { start, test });
+};
+
+/** @typedef {ReturnType<typeof make>} FreshMaker */
+/** @typedef {ReturnType<FreshMaker['start']>} Fresh */

--- a/contract/test/endo/jack-trade.js
+++ b/contract/test/endo/jack-trade.js
@@ -1,0 +1,71 @@
+// @ts-check
+import { E, Far } from '@endo/far';
+import { mustMatch, M } from '@endo/patterns';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
+
+import {
+  feeValue,
+  wellKnownIdentities,
+  contractName,
+} from './well-known.js/index.js';
+
+/**
+ * @param {import('./ag-trade.js').QueryTool} vstorage
+ * @param {import('./ag-trade.js').SmartWallet} wallet
+ */
+const jack = async (vstorage, wallet) => {
+  /**
+   * @param {string|number} id
+   * @param {Amount} beansAmount
+   * @param {Amount} cowsAmount
+   * @param {boolean} [jackPays]
+   */
+  const trade = async (id, beansAmount, cowsAmount, jackPays = false) => {
+    mustMatch(
+      harden({ id, beansAmount, cowsAmount, jackPays }),
+      harden({
+        id: M.string(),
+        beansAmount: AmountShape,
+        cowsAmount: AmountShape,
+        jackPays: M.boolean(),
+      }),
+    );
+    const wellKnown = await wellKnownIdentities(vstorage);
+
+    const feeAmount = AmountMath.make(wellKnown.brand.IST, feeValue);
+    const proposal = {
+      want: { MagicBeans: beansAmount },
+      give: {
+        Cow: cowsAmount,
+        ...(jackPays ? { Refund: feeAmount } : {}),
+      },
+    };
+
+    /** @type {import('./ag-trade.js').OfferSpec} */
+    const offerSpec = {
+      id,
+      invitationSpec: {
+        source: 'purse',
+        instance: wellKnown.instance[contractName],
+        description: 'matchOffer',
+      },
+      proposal,
+    };
+
+    return E(wallet).executeOffer(offerSpec);
+  };
+
+  return Far('Jack', { wellKnown: () => wellKnownIdentities(vstorage), trade });
+};
+
+export const make = async powers => {
+  /** @type {import('./ag-trade.js').SmartWalletKit} */
+  const kit = await E(powers).request(
+    'HOST',
+    'smartWallet kit for alice',
+    'walletKit',
+  );
+
+  return jack(kit.query, kit.smartWallet);
+};

--- a/contract/test/endo/mint-kread.js
+++ b/contract/test/endo/mint-kread.js
@@ -1,0 +1,58 @@
+// cribbed from
+// test.serial('--| MINT - Expected flow', ...)
+// https://github.com/Kryha/KREAd/blob/develop/agoric/contract/test/test-minting.js#L163
+// @ts-check
+
+import { E, Far } from '@endo/far';
+import { UNIT6 } from './well-known.js/index.js';
+
+console.log('*** mint-kread worker');
+
+/**
+ * @param {import('./ag-trade.js').QueryTool} vstorage
+ * @param {import('./ag-trade.js').SmartWallet} wallet
+ */
+const makeTrader = (vstorage, wallet) => {
+  /**
+   * @param {string|number} id
+   * @param {string} name
+   * @param {number} price
+   */
+  const trade = async (id, name, price = 25) => {
+    const instance = await E(vstorage).lookup(
+      'agoricNames',
+      'instance',
+      'kread',
+    );
+    const brand = {
+      IST: await E(vstorage).lookup('agoricNames', 'brand', 'IST'),
+    };
+    const Price = harden({
+      brand: brand.IST,
+      value: BigInt(Math.round(price * Number(UNIT6))),
+    });
+
+    /** @type {import('./ag-trade.js').OfferSpec} */
+    const offerSpec = {
+      id,
+      invitationSpec: {
+        source: 'contract',
+        instance,
+        publicInvitationMaker: 'makeMintCharacterInvitation',
+      },
+      proposal: { give: { Price } },
+      offerArgs: { name },
+    };
+
+    return E(wallet).executeOffer(offerSpec);
+  };
+
+  return Far('Trader', { trade });
+};
+
+export const make = async powers => {
+  /** @type {import('./ag-trade.js').SmartWalletKit} */
+  const kit = await E(powers).request('HOST', 'wallet kit', 'wallet-kit');
+
+  return makeTrader(kit.query, kit.smartWallet);
+};

--- a/contract/test/endo/net-local.js
+++ b/contract/test/endo/net-local.js
@@ -1,0 +1,22 @@
+/**
+ * Usage:
+ * $ endo make --UNSAFE src/cosmosFetch.js -n cosmos-fetch
+ * Object [Alleged: CosmosFetch] {}
+ * $ endo make test/net-local.js -n local -p cosmos-fetch
+ * { lcd: Object [Alleged: LCD] {}, rpc: Object [Alleged: RpcClient] {} }
+ */
+import { E } from '@endo/far';
+
+const loc = {
+  lcd: 'http://localhost:1317',
+  rpc: 'http://localhost:26657',
+};
+
+export const make = async net => {
+  const [lcd, rpc] = await Promise.all([
+    E(net).makeLCDClient(loc.lcd),
+    E(net).makeRPCClient(loc.rpc),
+  ]);
+
+  return harden({ lcd, rpc });
+};

--- a/contract/test/endo/reserve-add.js
+++ b/contract/test/endo/reserve-add.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import { E } from '@endo/far';
+
+const UNIT6 = 1_000_000n;
+
+/**
+ * @param {*} self
+ * @param {string} units
+ * @param {string} brandName
+ */
+export const main = async (self, units, brandName) => {
+  assert.typeof(units, 'string');
+  assert.typeof(brandName, 'string');
+  /** @type {import("./endo/ag-trade").SmartWalletKit} */
+  const { query: vstorage, smartWallet } = await E(self).lookup('wallet');
+  /** @type {Brand<'nat'>} */
+  const brand = await E(vstorage).lookup('agoricNames', 'brand', brandName);
+  /** @type {ERef<import('./endo/fresh-id').Fresh>} */
+  const fresh = E(self).lookup('fresh');
+
+  // TODO: lookup decimalPlaces by brand
+  const Collateral = { brand, value: UNIT6 * BigInt(units) };
+  const id = await E(fresh).next();
+
+  /** @type {import('@agoric/smart-wallet/src/offers.js').OfferSpec} */
+  const offerSpec = {
+    id,
+    invitationSpec: {
+      source: 'agoricContract',
+      instancePath: ['reserve'],
+      callPipe: [['makeAddCollateralInvitation', []]],
+    },
+    proposal: { give: { Collateral } },
+  };
+
+  const info = await E(smartWallet).executeOffer(offerSpec);
+  return info;
+};

--- a/contract/test/endo/well-known.js
+++ b/contract/test/endo/well-known.js
@@ -1,0 +1,56 @@
+// @ts-check
+import { E } from '@endo/far';
+
+export const contractName = 'swaparoo';
+
+export const UNIT6 = 1_000_000n;
+
+// Let's presume the terms are in vstorage somewhere... say... boardAux
+export const feeValue = 1n * UNIT6;
+
+const { entries, fromEntries } = Object;
+
+/** @type { <T extends Record<string, ERef<any>>>(obj: T) => Promise<{ [K in keyof T]: Awaited<T[K]>}> } */
+export const allValues = async obj => {
+  const es = await Promise.all(
+    entries(obj).map(([p, vp]) => Promise.resolve(vp).then(v => [p, v])),
+  );
+  return fromEntries(es);
+};
+
+// should be able to factor this out
+// const agoricNames = E(vstorage).lookup('agoricNames');
+/**
+ * @param {import('./ag-trade').QueryTool} vstorage
+ */
+export const wellKnownIdentities = async vstorage =>
+  allValues({
+    instance: allValues({
+      /** @type {Promise<Instance>} */
+      [contractName]: E(vstorage).lookup(
+        'agoricNames',
+        'instance',
+        contractName,
+      ),
+    }),
+    installation: allValues({
+      /** @type {Promise<Installation>} */
+      [contractName]: E(vstorage).lookup(
+        'agoricNames',
+        'installation',
+        contractName,
+      ),
+    }),
+    brand: allValues({
+      /** @type {Promise<Brand<'nat'>>} */
+      IST: E(vstorage).lookup('agoricNames', 'brand', 'IST'),
+      /** @type {Promise<Brand<'nat'>>} */
+      BLD: E(vstorage).lookup('agoricNames', 'brand', 'BLD'),
+    }),
+    issuer: allValues({
+      /** @type {Promise<Issuer<'nat'>>} */
+      IST: E(vstorage).lookup('agoricNames', 'issuer', 'IST'),
+      /** @type {Promise<Issuer<'nat'>>} */
+      BLD: E(vstorage).lookup('agoricNames', 'issuer', 'BLD'),
+    }),
+  });


### PR DESCRIPTION
@dtribble I got some clues from @kriskowal on how to use the `endo` cli/daemon, and it's starting to feel usable.

I haven't packaged up the swaparoo trade yet, but this shows adding 1 IST to the reserve

WIP:
 - [ ] depends on having [ag-trade](https://github.com/dckc/finquick/tree/ag-trade/packages/ag-trade) stuff checked out nearby
 - [ ] package up swaparoo trade

<details><summary>demo run log of endo-based trading agent</summary>

```
~/projects/dapp-swaparoo/contract$ make -C test/endo
make: Entering directory '/home/connolly/projects/dapp-swaparoo/contract/test/endo'
make -C ~/projects/finquick/packages/ag-trade /home/connolly/.local/state/endo/pet-store/cosmos-fetch
make[1]: Entering directory '/home/connolly/projects/finquick/packages/ag-trade'

++ install cosmos fetch plugin
endo make --UNSAFE src/cosmosFetch.js -n cosmos-fetch
Object [Alleged: CosmosFetch] {}
make[1]: Leaving directory '/home/connolly/projects/finquick/packages/ag-trade'

endo make net-local.js -n local -p cosmos-fetch
{ lcd: Object [Alleged: LCD] {}, rpc: Object [Alleged: RpcClient] {} }

make -C ~/projects/finquick/packages/ag-trade /home/connolly/.local/state/endo/pet-store/client-maker
make[1]: Entering directory '/home/connolly/projects/finquick/packages/ag-trade'
++ start smart wallet caplet -- TODO: should not need UNSAFE
endo make --UNSAFE src/smartWallet.js -n client-maker
Object [Alleged: SmartWalletFactory] {}
make[1]: Leaving directory '/home/connolly/projects/finquick/packages/ag-trade'

endo eval "E(wf).makeWalletKit('a...24 words...ct', local.rpc, local.lcd)" \
        local wf:client-maker -n alice-wk
{
  query: Object [Alleged: QueryTool] {},
  smartWallet: Object [Alleged: SmartWallet] {},
  tx: Object [Alleged: SigningClient] {}
}

endo make --UNSAFE fresh-id.js -n fresh
Object [Alleged: FreshMaker] {}
endo eval "E(fresh).start('trade-')" fresh -n fresh-trade-id
Object [Alleged: Fresh] {}

endo mkguest alice
Object [Alleged: EndoGuest] {}
endo send alice @wallet:alice-wk
endo send alice @fresh:fresh-trade-id
endo inbox --as alice
0. "HOST" sent "@wallet" at "2023-12-30T04:47:40.149Z"
1. "HOST" sent "@fresh" at "2023-12-30T04:47:40.242Z"
# these 0/1 message numbers are fragile
endo adopt 0 wallet --as alice
endo adopt 1 fresh --as alice

endo run reserve-add.js 1 IST -p alice
{
  status: {
    id: 'trade-0447.0',
    invitationSpec: {
      callPipe: [Array],
      instancePath: [Array],
      source: 'agoricContract'
    },
    numWantsSatisfied: 1,
    payouts: { Collateral: [Object] },
    proposal: { give: [Object] },
    result: 'added Collateral to the Reserve'
  },
  tx: {
    height: 259168,
    transactionHash: '14ECA2BAF32F86FB5F77EF2D1F0768D61DFF25213ECFAD320D91C8614C2F977B'
  }
}
make: Leaving directory '/home/connolly/projects/dapp-swaparoo/contract/test/endo'
```

</details> 
