### PR TITLE
feat: Get more UI working

### DIFF
--- a/contract/Makefile
+++ b/contract/Makefile
@@ -84,6 +84,9 @@ install-bundles: bundles/bundle-list
 
 build-proposal: bundles/bundle-list
 
+agoric-install:
+	cd ..; agoric install --sdk
+
 bundles/bundle-list start-contract.js start-contract-permit.json: ./scripts/build-proposal.sh ./src/swaparoo.js
 	./scripts/build-proposal.sh
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,7 +14,6 @@ import {
 } from '@agoric/web-components';
 import { subscribeLatest } from '@agoric/notifier';
 import { stringifyAmountValue } from '@agoric/ui-components';
-import { makeCopyBag } from '@agoric/store';
 
 type Wallet = Awaited<ReturnType<typeof makeAgoricWalletConnection>>;
 
@@ -36,7 +35,7 @@ interface Invitation {
   description: string;
   handle: unknown;
   instance: unknown;
-  customDetails: { give: unknown, want: unknown };
+  customDetails: { give: object, want: object };
 }
 
 interface Purse {
@@ -163,11 +162,12 @@ const setFirstOffer = ({ recipient = undefined }) => {
   });
 };
 
-const setMatchOffer = (invite) => {
+const setMatchOffer = (invite: Invitation) => {
   const { give, want } = invite.customDetails;
   console.log('MATCH', give, want);
   // what if there isn't a Fee?
-  const { Fee: _ignore, ...withoutFee } = give;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { Fee, ...withoutFee } = give;
   useForm.setState({
     recipient: undefined,
     give: want,
@@ -315,7 +315,15 @@ const BuildOffer = wallet => {
           )}
         </div>
       </div>
-      <div>
+      <div style={{ textAlign: 'left' }}>
+        <h4  >GIVE </h4>
+        <p>
+        </p>
+        <h4 className="want" >WANT </h4>
+        <p>
+          {stringify(want) || 'Not yet provided'}
+        </p>
+        <br />
         <label className="address" >Address:
           <input
             type="text"
@@ -324,22 +332,7 @@ const BuildOffer = wallet => {
             style={{ width: "30em" }}
           />
         </label>
-        <br />
-        <label className="give" >GIVE
-          <input
-            type="text"
-            value={stringify(give)}
-            style={{ width: "30em" }}
-          />
-        </label>
-        <br />
-        <label className="want" >WANT
-          <input
-            type="text"
-            value={stringify(want)}
-            style={{ width: "30em" }}
-          />
-        </label>
+
         <br />
         {/* // select give asset
         // fill give amount (with max button?)
@@ -350,10 +343,10 @@ const BuildOffer = wallet => {
         <button onClick={() => setFirstOffer(useForm.getState())}>First Offer</button>
         <button onClick={() => makeOffer(useForm.getState())}>Make Offer</button>
         <br />
-        <button onClick={() => setMatchOffer(swaps[0])}>Match First</button>
-        <button onClick={() => makeSecondOffer(useForm.getState())}>Make Offer</button>
+        <button onClick={() => setMatchOffer(swaps[0])} disabled={!swaps.length}>Match First</button>
+        <button onClick={() => makeSecondOffer(useForm.getState())} disabled={!swaps.length}>Make Second Offer</button>
       </div>
-    </div>
+    </div >
   );
 };
 
@@ -366,7 +359,7 @@ const App = () => {
 
   return (
     <div>
-      <Banner wallet={wallet} />
+      <Banner />
       {wallet ? (
         <BuildOffer />
       ) :

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -318,6 +318,7 @@ const BuildOffer = wallet => {
       <div style={{ textAlign: 'left' }}>
         <h4  >GIVE </h4>
         <p>
+          {stringify(give) || 'Not yet provided'}
         </p>
         <h4 className="want" >WANT </h4>
         <p>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,7 +19,9 @@ import { makeCopyBag } from '@agoric/store';
 type Wallet = Awaited<ReturnType<typeof makeAgoricWalletConnection>>;
 
 export const contractName = 'swaparoo';
-const gov1 = 'agoric14t2eagaphnkj33l9hvcrf90t3xffkt0u3xy6uh';
+// const gov1 = 'agoric14t2eagaphnkj33l9hvcrf90t3xffkt0u3xy6uh';
+const swappa = 'agoric13whlmf7akvmg05n3zx37v7r0htyasa4m28j9cu';
+const recipientAddr = swappa;
 
 const watcher = makeAgoricChainStorageWatcher(
   'http://localhost:26657',
@@ -123,7 +125,7 @@ const makeOffer = () => {
       invitationArgs: [[istIssuer, bldIssuer]],
     },
     { give, want },
-    { addr: gov1 },
+    { addr: recipientAddr },
     (update: { status: string; data?: unknown }) => {
       if (update.status === 'error') {
         alert(`Offer error: ${update.data}`);
@@ -150,7 +152,9 @@ function App() {
   const istPurse = purses?.find(p => p.brandPetname === 'IST');
   const bldPurse = purses?.find(p => p.brandPetname === 'BLD');
   const invitationPurse = purses?.find(p => p.brandPetname === 'Invitation');
+  console.log("INVITE PURSE", invitationPurse);
   const invites = invitationPurse ? invitationPurse.currentAmount.value as Array : [];
+  console.log("INVITES", invites);
 
   const buttonLabel = wallet ? 'Make Offer' : 'Connect Wallet';
   const onClick = () => {
@@ -211,9 +215,9 @@ function App() {
                   invites.length ? (
                     <ul style={{ marginTop: 0, textAlign: 'left' }}>
                       {invites.map(
-                        ([name, number]) => (
-                          <li key={name}>
-                            {String(number)} {name}
+                        ({ description, customDetails }, index) => (
+                          <li key={index}>
+                            {description} {JSON.stringify(customDetails, (k, v) => typeof v === 'bigint' ? `${v}` : v)}
                           </li>
                         )
                       )}


### PR DESCRIPTION
- make `address` a parameter
- better factor the main window
- use a store for the in-progress offer
- show received 2nd party invites
- button to setup the first and second offers
- enable second offer if invite is present

Note that "Make Second Offer" is different because it's making a "Purse" offer rather than a "Contract" offer (which determines where the invitation is found).

After "Connect Wallet"
<img width="822" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/248cabae-6458-4667-8b1e-81066f3b17d6">

After "First Offer"
<img width="822" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/82296687-bc32-4a37-84c2-3558ac49b816">

After "Make Offer"
<img width="822" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/592165b1-e89f-48e3-9759-795725727124">

As user "swappa"
<img width="1205" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/eb99c2b2-e1e4-412e-898c-3dbc7b9058b4">

After "Match First", then "Make Second Offer"
<img width="1205" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/f89b8536-8e48-48bb-8d32-589dcdaadd96">

Success
<img width="768" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/3595c723-3779-4e3f-993f-f1277797050e">

<img width="768" alt="image" src="https://github.com/agoric-labs/dapp-swaparoo/assets/739213/e90b7bf0-c92f-487d-88c2-b1b823993ddc">

